### PR TITLE
[DF-888] Use the data if we have it, rather than make 2 more requests

### DIFF
--- a/lib/webpagetest/client.rb
+++ b/lib/webpagetest/client.rb
@@ -49,7 +49,7 @@ module Webpagetest
       test_params = Hashie::Mash.new( {test: test_id, pagespeed: 1} )
       response = make_request(RESULT_BASE, test_params)
       return not_available (response) unless response.status == 200
-      @response = Response.new(self, Hashie::Mash.new(JSON.parse(response.body)), false)
+      @response = Response.new(self, HashieResponse.new(JSON.parse(response.body)), false)
     end
 
     # Gets all available test locations


### PR DESCRIPTION
Audience: Product

**Summary:** We have the results available to parse as soon as we have a completed test. But the gem was originally written to require 2-3 separate requests. This PR will allow the following workflow:

1. start a test for a site and get the test id back.
2. poll `response = client.test_result(test_id)` then ask `response.status` for the status
3. when the status is `:completed`, call `response.result` for the formatted response

From there, we can pass the results on to a processor to do whatever work we need before persisting it.

**To-do:**
- update readme