### PR TITLE
[DF-1180] Expose site test status endpoint in webpagetest gem

### DIFF
--- a/lib/webpagetest/client.rb
+++ b/lib/webpagetest/client.rb
@@ -7,8 +7,6 @@ module Webpagetest
 
     TEST_BASE = 'runtest.php'
     LOCATIONS_BASE = 'getLocations.php'
-    RESULT_BASE = Response::RESULT_BASE
-    STATUS_BASE = Response::STATUS_BASE
 
     # Main params for running tests
     def initialize(params = {})
@@ -47,16 +45,16 @@ module Webpagetest
 
     # Gets the status of a test based on its id
     def test_status(test_id)
-      test_params = Hashie::Mash.new({test: test_id, pagespeed: 1} )
-      response = make_request(STATUS_BASE, test_params)
+      test_params = Hashie::Mash.new({test: test_id, pagespeed: 1})
+      response = make_request(Response::STATUS_BASE, test_params)
       return not_available (response) unless response.status == 200
       @response = Response.new(self, HashieResponse.new(JSON.parse(response.body)), false)
     end
 
     # Gets the result of a test based on its id
     def test_result(test_id)
-      test_params = Hashie::Mash.new( {test: test_id, pagespeed: 1} )
-      response = make_request(RESULT_BASE, test_params)
+      test_params = Hashie::Mash.new({test: test_id, pagespeed: 1})
+      response = make_request(Response::RESULT_BASE, test_params)
       return not_available (response) unless response.status == 200
       @response = Response.new(self, HashieResponse.new(JSON.parse(response.body)), false)
     end

--- a/lib/webpagetest/client.rb
+++ b/lib/webpagetest/client.rb
@@ -7,7 +7,8 @@ module Webpagetest
 
     TEST_BASE = 'runtest.php'
     LOCATIONS_BASE = 'getLocations.php'
-    RESULT_BASE = 'jsonResult.php'
+    RESULT_BASE = Response::RESULT_BASE
+    STATUS_BASE = Response::STATUS_BASE
 
     # Main params for running tests
     def initialize(params = {})
@@ -42,6 +43,14 @@ module Webpagetest
       end
       return not_available (response) unless response.status == 200
       @response = Response.new(self, Hashie::Mash.new(JSON.parse(response.body)))
+    end
+
+    # Gets the status of a test based on its id
+    def test_status(test_id)
+      test_params = Hashie::Mash.new({test: test_id, pagespeed: 1} )
+      response = make_request(STATUS_BASE, test_params)
+      return not_available (response) unless response.status == 200
+      @response = Response.new(self, HashieResponse.new(JSON.parse(response.body)), false)
     end
 
     # Gets the result of a test based on its id

--- a/lib/webpagetest/version.rb
+++ b/lib/webpagetest/version.rb
@@ -1,3 +1,3 @@
 module Webpagetest
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Now that we're going to be harvesting full WPT results in GCP GoHarvest Cloud Function, we'll need a lightweight way to check the status of the WPT test on the WPT instance before triggering processing through the function. 

Calling `Webpagetest::Client#test_result` fetches back full WPT response body payload if available. I think that's still desirable behavior, so I tweaked the Client class to add a new `test_status` endpoint. This pings a totally separate endpoint and brings back basic information about the test, including if it's available.

**Technical:**

- Cloud Function: https://console.cloud.google.com/functions/details/us-central1/go-harvest?project=flywheel-performance&tab=general&duration=PT1H
- WPT Compute Instance: https://console.cloud.google.com/compute/instancesDetail/zones/us-central1-a/instances/webpage-test-server-www?project=flywheel-performance

Result endpoint example: https://webpagetest.dev.getflywheel.com/jsonResult.php?test=191208_YV_1&pagespeed=1

Status endpoint example: https://webpagetest.dev.getflywheel.com/testStatus.php?test=191208_YV_1&pagespeed=1

New status invocation example (which hits the above status endpoint): 

```
Webpagetest.new(k: <your_api_key>, options: { your_connection_options }).test_status("191208_YV_1")
```